### PR TITLE
Fix Docker build context paths in Dockerfile

### DIFF
--- a/mcp-proxy-manager/Dockerfile
+++ b/mcp-proxy-manager/Dockerfile
@@ -64,12 +64,12 @@ RUN npm install -g playwright \
 # Note: SuperGateway will be installed via npx on-demand to avoid dependency issues
 
 # Copy package files and install dependencies
-COPY mcp-proxy-manager/package*.json ./
+COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 
 # Copy application code and Jest configuration
-COPY mcp-proxy-manager/src/ ./src/
-COPY mcp-proxy-manager/jest.config.js ./
+COPY src/ ./src/
+COPY jest.config.js ./
 
 # Stage 2: Runtime environment (minimal)
 FROM node:22-slim AS runtime


### PR DESCRIPTION
## Summary

- Fix COPY commands in Dockerfile to use correct relative paths for build context
- Resolves docker build failure: `failed to compute cache key: "/mcp-proxy-manager/jest.config.js": not found`

## Problem

The docker-compose.yml specifies `context: ./mcp-proxy-manager`, but Dockerfile COPY commands were using absolute paths as if the context was the root directory.

## Changes

- `COPY mcp-proxy-manager/package*.json ./` → `COPY package*.json ./`
- `COPY mcp-proxy-manager/src/ ./src/` → `COPY src/ ./src/`  
- `COPY mcp-proxy-manager/jest.config.js ./` → `COPY jest.config.js ./`

## Test Plan

- [x] Docker build completes successfully
- [ ] Container starts without errors
- [ ] All existing functionality preserved
- [ ] CI/CD pipeline passes